### PR TITLE
Simple auth support

### DIFF
--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -28,7 +28,7 @@ class Git:
             index = p.expect(['Password for .*:', pexpect.EOF, pexpect.TIMEOUT])
             if index==0:
                 p.sendline(password)
-                index = p.expect([pexpect.EOF, pexpect.TIMEOUT])
+                index = p.expect([pexpect.EOF, 'fatal*', pexpect.TIMEOUT])
                 if index==0:
                     p.close()
                     return 0
@@ -532,7 +532,7 @@ class Git:
                 }
             else:
                 response = {
-                    'code': 128,
+                    'code': 1,
                     'message': 'Auth or timeout error'
                 }
         else:

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -27,16 +27,17 @@ class git_auth_input_wrapper:
             p.sendline(self.password)
 
             p.expect(pexpect.EOF)
-            response = p.before.decode('utf-8')
+            response = p.before
 
             self.returncode = p.wait()
             p.close()
             
             return response
-        except pexpect.exceptions.EOF as e: #In case of pexpect failure
+        except pexpect.exceptions.EOF: #In case of pexpect failure
+            response = p.before
+            self.returncode = p.exitstatus
             p.close() #close process
-            self.returncode = -1
-            return e.value
+            return response
 
 class Git:
     """
@@ -76,14 +77,13 @@ class Git:
                 cwd=os.path.join(self.root_dir, current_path),
             )
             _, error = p.communicate()
-            error = error.decode('utf-8').strip()
         
         response = {
             'code': p.returncode
         }
 
         if p.returncode != 0:
-            response['message'] = error
+            response['message'] = error.decode('utf-8').strip()
 
         return response
 
@@ -540,14 +540,13 @@ class Git:
                 cwd=os.path.join(self.root_dir, curr_fb_path),
             )
             _, error = p.communicate()
-            error = error.decode('utf-8').strip()
         
         response = {
             'code': p.returncode
         }
 
         if p.returncode != 0:
-            response['message'] = error
+            response['message'] = error.decode('utf-8').strip()
 
         return response
 
@@ -573,14 +572,13 @@ class Git:
                 cwd=os.path.join(self.root_dir, curr_fb_path),
             )
             _, error = p.communicate()
-            error = error.decode('utf-8').strip()
         
         response = {
             'code': p.returncode
         }
 
         if p.returncode != 0:
-            response['message'] = error
+            response['message'] = error.decode('utf-8').strip()
         
         return response
 

--- a/jupyterlab_git/git.py
+++ b/jupyterlab_git/git.py
@@ -435,14 +435,41 @@ class Git:
         )
         return my_output
 
-    def commit(self, commit_msg, top_repo_path):
+    def commit(self, commit_msg, top_repo_path, author_name=None, author_email=None):
         """
         Execute git commit <filename> command & return the result.
         """
-        my_output = subprocess.check_output(
-            ["git", "commit", "-m", commit_msg], cwd=top_repo_path
+        #Check for errors (i.e. no author set up)
+        #my_output = subprocess.check_output(
+        #    ["git", "commit", "-m", commit_msg], cwd=top_repo_path
+        #)
+
+        command = ["git", "commit", "-m", commit_msg]
+
+        if author_name != None and author_email != None:
+            command.insert(1, '-c')
+            command.insert(2, f'user.name=\'{author_name}\'')
+            command.insert(3, '-c')
+            command.insert(4, f'user.email=\'{author_email}\'')
+
+        p = Popen(
+            command,
+            stdout=PIPE,
+            stderr=PIPE,
+            cwd=top_repo_path,
         )
-        return my_output
+        my_output, my_error = p.communicate()
+        
+        if p.returncode == 0:
+            return {
+                "code": p.returncode,
+                "message": my_output.decode("utf-8").strip("\n"),
+            }
+        else:
+            return {
+                "code": p.returncode,
+                "message": my_error.decode("utf-8").strip("\n"),
+            }
 
     def pull(self, curr_fb_path):
         """

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -36,11 +36,8 @@ class GitCloneHandler(GitHandler):
         clone_url = data['clone_url']
 
         #Different request with and without auth
-        if "username" in data.keys() and "password" in data.keys():
-            auth = {
-                'username': data["username"],
-                'password': data["password"]
-            }
+        if 'auth' in data.keys():
+            auth = data['auth']
             response = self.git.clone(path, clone_url, auth)
         else:
             response = self.git.clone(path, clone_url)
@@ -367,11 +364,8 @@ class GitPullHandler(GitHandler):
         path = data['current_path']
 
         #Different request with and without auth
-        if "username" in data.keys() and "password" in data.keys():
-            auth = {
-                'username': data["username"],
-                'password': data["password"]
-            }
+        if 'auth' in data.keys():
+            auth = data['auth']
             response = self.git.pull(path, auth)
         else:
             response = self.git.pull(path)
@@ -409,11 +403,8 @@ class GitPushHandler(GitHandler):
                 branch = ':'.join(['HEAD', upstream[1]])
 
             #Different request with and without auth
-            if "username" in data.keys() and "password" in data.keys():
-                auth = {
-                    'username': data["username"],
-                    'password': data["password"]
-                }
+            if 'auth' in data.keys():
+                auth = data['auth']
                 response = self.git.push(remote, branch, current_path, auth)
             else:
                 response = self.git.push(remote, branch, current_path)

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -312,8 +312,14 @@ class GitCommitHandler(GitHandler):
         data = self.get_json_body()
         top_repo_path = data["top_repo_path"]
         commit_msg = data["commit_msg"]
-        my_output = self.git.commit(commit_msg, top_repo_path)
-        self.finish(my_output)
+        if "author_name" in data.keys() and "author_email" in data.keys():
+            author_name = data["author_name"]
+            author_email = data["author_email"]
+            my_output = self.git.commit(commit_msg, top_repo_path, author_name, author_email)
+        else:
+            my_output = self.git.commit(commit_msg, top_repo_path)
+        
+        self.finish(json.dumps(my_output))
 
 
 class GitUpstreamHandler(GitHandler):

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -27,7 +27,9 @@ class GitCloneHandler(GitHandler):
             {
               'current_path': 'current_file_browser_path',
               'repo_url': 'https://github.com/path/to/myrepo'
-              OPTIONAL 'auth': 
+              OPTIONAL 'auth': '{ 'username': '<username>',
+                                  'password': '<password>'
+                                }'
             }
         """
         data = self.get_json_body()
@@ -312,6 +314,16 @@ class GitCheckoutHandler(GitHandler):
 class GitCommitHandler(GitHandler):
     """
     Handler for 'git commit -m <message>'. Commits files.
+
+    When author information is sent, adds that information to commit
+
+    Input format:
+        {
+            'top_repo_path': 'top/repo/path',
+            'commit_msg': 'commit_message_to_add',
+            OPTIONAL: 'author_name' : 'Notebook User',
+            OPTIONAL: 'author_email' : 'email@domain.com'
+        }
     """
 
     def post(self):

--- a/jupyterlab_git/handlers.py
+++ b/jupyterlab_git/handlers.py
@@ -27,10 +27,24 @@ class GitCloneHandler(GitHandler):
             {
               'current_path': 'current_file_browser_path',
               'repo_url': 'https://github.com/path/to/myrepo'
+              OPTIONAL 'auth': 
             }
         """
-        data = json.loads(self.request.body.decode('utf-8'))
-        response = self.git.clone(data['current_path'], data['clone_url'])
+        data = self.get_json_body()
+        
+        path = data['current_path']
+        clone_url = data['clone_url']
+
+        #Different request with and without auth
+        if "username" in data.keys() and "password" in data.keys():
+            auth = {
+                'username': data["username"],
+                'password': data["password"]
+            }
+            response = self.git.clone(path, clone_url, auth)
+        else:
+            response = self.git.clone(path, clone_url)
+
         self.finish(json.dumps(response))
 
 

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -305,7 +305,7 @@ export class BranchHeader extends React.Component<
 }
 
 /**
- * The UI for the credentials form
+ * The UI for the commit author form
  */
 class GitAuthorForm extends Widget {
     

--- a/src/components/BranchHeader.tsx
+++ b/src/components/BranchHeader.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
 
+import {
+  Dialog
+} from "@jupyterlab/apputils";
+
+import {
+  Widget
+} from "@phosphor/widgets";
+
 import { Git } from '../git';
 
 import { CommitBox } from './CommitBox';
@@ -70,9 +78,32 @@ export class BranchHeader extends React.Component<
   commitAllStagedFiles = (message: string, path: string): void => {
     if (message && message !== '') {
       let gitApi = new Git();
-      gitApi.commit(message, path).then(response => {
-        this.props.refresh();
-      });
+      gitApi.commit(message, path)
+        .then(async response => {
+          if (response.code == 128 && response.message.indexOf('Please tell me who you are')>=0) {
+            
+            const dialog = new Dialog({
+              title: 'Git credentials required',
+              body: new GitAuthorForm(),
+              buttons: [
+                  Dialog.cancelButton(),
+                  Dialog.okButton({label: 'OK'})
+              ]
+            });
+            const result = await dialog.launch();
+            dialog.dispose();
+
+            if (result.button.label == 'OK') {
+              let author = JSON.parse(decodeURIComponent(result.value));
+              //call gitApi.commit again with the author info
+              gitApi.commit(message, path, author.name, author.email)
+              
+          }
+
+          }
+
+          this.props.refresh();
+        });
     }
   };
 
@@ -271,4 +302,53 @@ export class BranchHeader extends React.Component<
       </div>
     );
   }
+}
+
+/**
+ * The UI for the credentials form
+ */
+class GitAuthorForm extends Widget {
+    
+  /**
+   * Create a redirect form.
+   */
+  constructor() {
+      super({node: GitAuthorForm.createFormNode()});
+  }
+
+  private static createFormNode(): HTMLElement {
+      const node = document.createElement('div');
+      const label = document.createElement('label');
+      const name = document.createElement('input');
+      const email = document.createElement('input');
+
+      const text = document.createElement('span');
+      const warning = document.createElement('div');
+
+      node.className = 'jp-RedirectForm';
+      warning.className = 'jp-RedirectForm-warning';
+      text.textContent = 'Enter your name and email for commit';
+      name.placeholder = 'Name';
+      email.placeholder = 'Email';
+
+      label.appendChild(text);
+      label.appendChild(name);
+      label.appendChild(email);
+      node.appendChild(label);
+      node.appendChild(warning);
+      return node;
+  }
+
+  /**
+   * Returns the input value.
+   */
+  getValue(): string {
+      let lines = this.node.querySelectorAll('input');
+      let credentials = {
+          name: lines[0].value,
+          email : lines[1].value,
+      }
+      return encodeURIComponent(JSON.stringify(credentials));
+  }
+
 }

--- a/src/components/CredentialsBox.tsx
+++ b/src/components/CredentialsBox.tsx
@@ -1,0 +1,63 @@
+import {
+    Widget
+} from "@phosphor/widgets";
+
+/**
+ * The UI for the credentials form
+ */
+export class GitCredentialsForm extends Widget {
+    
+    /**
+     * Create a redirect form.
+     */
+    constructor(textContent : string = 'Enter credentials for remote repository', warningContent: string = '') {
+        super({node: GitCredentialsForm.createFormNode(textContent, warningContent)});
+    }
+
+    
+  
+    private static createFormNode(textContent : string, warningContent: string): HTMLElement {
+        const node = document.createElement('div');
+        const label = document.createElement('label');
+        const user = document.createElement('input');
+        const password = document.createElement('input');
+        password.type = 'password';
+        password.id = 'git_password';
+  
+        const text = document.createElement('span');
+        const warning = document.createElement('div');
+  
+        node.className = 'jp-RedirectForm';
+        warning.className = 'jp-RedirectForm-warning';
+        text.textContent = textContent;
+        warning.textContent = warningContent;
+        user.placeholder = 'username';
+        password.placeholder = 'password';
+  
+        label.appendChild(text);
+        label.appendChild(user);
+        label.appendChild(password);
+        node.appendChild(label);
+        node.appendChild(warning);
+        return node;
+    }
+
+    setText(text: string): void {
+        
+        let textBox = this.node.querySelector('span');
+        textBox.nodeValue = text;
+    }
+  
+    /**
+     * Returns the input value.
+     */
+    getValue(): string {
+        let lines = this.node.querySelectorAll('input');
+        let credentials = {
+            username: lines[0].value,
+            password : lines[1].value,
+        }
+        return encodeURIComponent(JSON.stringify(credentials));
+    }
+  
+  }

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -74,7 +74,7 @@ export class PathHeader extends React.Component<IPathHeaderProps,
       .then(async response => {
         let retry = false;
         while (response.code != 0) {
-          if (response.code == 1 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Auth or timeout error')>=0)) {
+          if (response.code == 1 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Invalid username or password')>=0)) {
             const dialog = new Dialog({
               title: 'Git credentials required',
               body: new GitCredentialsForm('Enter credentials for remote repository', retry ? 'Incorrect username or password.' : ''),
@@ -122,7 +122,7 @@ export class PathHeader extends React.Component<IPathHeaderProps,
       .then(async response => {
         let retry = false;
         while (response.code != 0) {
-          if (response.code == 128 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Auth or timeout error')>=0)) {
+          if (response.code == 128 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Invalid username or password')>=0)) {
             const dialog = new Dialog({
               title: 'Git credentials required',
               body: new GitCredentialsForm('Enter credentials for remote repository', retry ? 'Incorrect username or password.' : ''),

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -6,6 +6,10 @@ import {
   repoStyle
 } from '../componentsStyle/PathHeaderStyle';
 
+import {
+  Widget
+} from "@phosphor/widgets";
+
 import * as React from 'react';
 
 import {classes} from 'typestyle';
@@ -69,9 +73,34 @@ export class PathHeader extends React.Component<IPathHeaderProps,
    */
   private executeGitPull(): void {
     this.state.gitApi.pull(this.props.currentFileBrowserPath)
-      .then(response => {
+      .then(async response => {
         if (response.code != 0) {
-          this.showErrorDialog('Pull failed', response.message);
+          if (response.code == 1 && response.message.indexOf('could not read Username')>=0) {
+            const dialog = new Dialog({
+              title: 'Git credentials required',
+              body: new GitCredentialsForm(),
+              buttons: [
+                  Dialog.cancelButton(),
+                  Dialog.okButton({label: 'OK'})
+              ]
+            });
+            const result = await dialog.launch();
+            dialog.dispose();
+
+            if (result.button.label == 'OK') {
+              let auth = JSON.parse(decodeURIComponent(result.value));
+              //call gitApi.pull again with credentials
+              this.state.gitApi.pull(this.props.currentFileBrowserPath, auth.username, auth.password);
+            }
+            else {
+              this.showErrorDialog('Push failed');
+            }
+          
+          }
+          else {
+            this.showErrorDialog('Pull failed', response.message);
+          }
+          
         }
       })
       .catch(() => this.showErrorDialog('Pull failed'));
@@ -82,9 +111,32 @@ export class PathHeader extends React.Component<IPathHeaderProps,
    */
   private executeGitPush(): void {
     this.state.gitApi.push(this.props.currentFileBrowserPath)
-      .then(response => {
+      .then(async response => {
         if (response.code != 0) {
-          this.showErrorDialog('Push failed', response.message);
+          if (response.code == 128 && response.message.indexOf('could not read Username')>=0) {
+            const dialog = new Dialog({
+              title: 'Git credentials required',
+              body: new GitCredentialsForm(),
+              buttons: [
+                  Dialog.cancelButton(),
+                  Dialog.okButton({label: 'OK'})
+              ]
+            });
+            const result = await dialog.launch();
+            dialog.dispose();
+
+            if (result.button.label == 'OK') {
+              let auth = JSON.parse(decodeURIComponent(result.value));
+              //call gitApi.push again with credentials
+              this.state.gitApi.push(this.props.currentFileBrowserPath, auth.username, auth.password);
+            }
+            else {
+              this.showErrorDialog('Push failed');
+            }
+          }
+          else {
+            this.showErrorDialog('Push failed', response.message);
+          }
         }
       })
       .catch(() => this.showErrorDialog('Push failed'));
@@ -104,4 +156,54 @@ export class PathHeader extends React.Component<IPathHeaderProps,
       // NO-OP
     });
   }
+}
+
+/**
+ * The UI for the credentials form
+ */
+class GitCredentialsForm extends Widget {
+    
+  /**
+   * Create a redirect form.
+   */
+  constructor() {
+      super({node: GitCredentialsForm.createFormNode()});
+  }
+
+  private static createFormNode(): HTMLElement {
+      const node = document.createElement('div');
+      const label = document.createElement('label');
+      const user = document.createElement('input');
+      const password = document.createElement('input');
+      password.type = 'password';
+      password.id = 'git_password';
+
+      const text = document.createElement('span');
+      const warning = document.createElement('div');
+
+      node.className = 'jp-RedirectForm';
+      warning.className = 'jp-RedirectForm-warning';
+      text.textContent = 'Enter credentials for provided repository';
+      user.placeholder = 'user';
+
+      label.appendChild(text);
+      label.appendChild(user);
+      label.appendChild(password);
+      node.appendChild(label);
+      node.appendChild(warning);
+      return node;
+  }
+
+  /**
+   * Returns the input value.
+   */
+  getValue(): string {
+      let lines = this.node.querySelectorAll('input');
+      let credentials = {
+          username: lines[0].value,
+          password : lines[1].value,
+      }
+      return encodeURIComponent(JSON.stringify(credentials));
+  }
+
 }

--- a/src/components/PathHeader.tsx
+++ b/src/components/PathHeader.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 
 import {classes} from 'typestyle';
 
-import {Git} from '../git';
+import {Git, authObject} from '../git';
 
 import {GitCredentialsForm} from './CredentialsBox'
 
@@ -88,9 +88,13 @@ export class PathHeader extends React.Component<IPathHeaderProps,
 
             if (result.button.label == 'OK') {
               //user accepted attempt to login
-              let auth = JSON.parse(decodeURIComponent(result.value));
+              let auth_json = JSON.parse(decodeURIComponent(result.value));
               //call gitApi.pull again with credentials
-              response = await this.state.gitApi.pull(this.props.currentFileBrowserPath, auth.username, auth.password);
+              let auth: authObject = {
+                username: auth_json.username,
+                password: auth_json.password
+              }
+              response = await this.state.gitApi.pull(this.props.currentFileBrowserPath, auth);
             }
             else {
               //user cancelled attempt to log in
@@ -132,9 +136,13 @@ export class PathHeader extends React.Component<IPathHeaderProps,
 
             if (result.button.label == 'OK') {
               //user accepted attempt to login
-              let auth = JSON.parse(decodeURIComponent(result.value));
+              let auth_json = JSON.parse(decodeURIComponent(result.value));
               //call gitApi.push again with credentials
-              response = await this.state.gitApi.push(this.props.currentFileBrowserPath, auth.username, auth.password);
+              let auth: authObject = {
+                username: auth_json.username,
+                password: auth_json.password
+              }
+              response = await this.state.gitApi.push(this.props.currentFileBrowserPath, auth);
             }
             else {
               //user cancelled attempt to log in

--- a/src/git.ts
+++ b/src/git.ts
@@ -155,16 +155,55 @@ export interface IGitPushPullResult {
   message?: string;
 }
 
+/**
+ * Structure for the request to the Git Push API.
+ */
+export interface pushObject {
+  current_path: string,
+  username?: string;
+  password?: string;
+}
+
+/**
+ * Structure for the request to the Git Pull API.
+ */
+export interface pullObject {
+  current_path: string,
+  username?: string;
+  password?: string;
+}
+
+/**
+ * Structure for the request to the Git Commit API.
+ */
+export interface commitObject {
+  commit_msg: string;
+  top_repo_path: string;
+  author_name?: string;
+  author_email?: string;
+}
+
 /** Parent class for all API requests */
 export class Git {
   constructor() {}
 
   /** Make request for the Git Pull API. */
-  async pull(path: string): Promise<IGitPushPullResult> {
+  async pull(path: string, username: string = '', password: string= ''): Promise<IGitPushPullResult> {
     try {
-      let response = await httpGitRequest('/git/pull', 'POST', {
-        current_path: path
-      });
+      if (username == '' && password == '') {
+        var obj: pullObject = { 
+          current_path: path, 
+        };
+      }
+      else {
+        var obj: pullObject = {
+          current_path: path,
+          username: username,
+          password: password
+        };
+      }
+
+      let response = await httpGitRequest('/git/pull', 'POST', obj);
       if (response.status !== 200) {
         const data = await response.json();
         throw new ServerConnection.ResponseError(response, data.message);
@@ -176,11 +215,22 @@ export class Git {
   }
 
   /** Make request for the Git Push API. */
-  async push(path: string): Promise<IGitPushPullResult> {
+  async push(path: string, username: string = '', password: string= ''): Promise<IGitPushPullResult> {
     try {
-      let response = await httpGitRequest('/git/push', 'POST', {
-        current_path: path
-      });
+      if (username == '' && password == '') {
+        var obj: pushObject = { 
+          current_path: path, 
+        };
+      }
+      else {
+        var obj: pushObject = {
+          current_path: path,
+          username: username,
+          password: password
+        };
+      }
+      let response = await httpGitRequest('/git/push', 'POST', obj);
+      
       if (response.status !== 200) {
         const data = await response.json();
         throw new ServerConnection.ResponseError(response, data.message);
@@ -390,13 +440,6 @@ export class Git {
   /** Make request to commit all staged files in repository 'path' */
   async commit(message: string, path: string, authorName: string = '', authorEmail: string= ''): Promise<GitCommitResult> {
     try {
-      interface commitObject {
-        commit_msg: string;
-        top_repo_path: string;
-        author_name?: string;
-        author_email?: string;
-      }
-
       if (authorName == '' && authorEmail == '') {
         var obj: commitObject = { 
           commit_msg: message, 

--- a/src/git.ts
+++ b/src/git.ts
@@ -156,6 +156,16 @@ export interface IGitPushPullResult {
 }
 
 /**
+ * Structure for the request to the Git Clone API.
+ */
+export interface cloneObject {
+  current_path: string,
+  clone_url: string,
+  username?: string;
+  password?: string;
+}
+
+/**
  * Structure for the request to the Git Push API.
  */
 export interface pushObject {
@@ -242,12 +252,24 @@ export class Git {
   }
 
   /** Make request for the Git Clone API. */
-  async clone(path: string, url: string): Promise<GitCloneResult> {
+  async clone(path: string, url: string, username: string = '', password: string= ''): Promise<GitCloneResult> {
     try {
-      let response = await httpGitRequest('/git/clone', 'POST', {
-        current_path: path,
-        clone_url: url
-      });
+      if (username == '' && password == '') {
+        var obj: cloneObject = { 
+          current_path: path, 
+          clone_url: url
+        };
+      }
+      else {
+        var obj: cloneObject = {
+          current_path: path,
+          clone_url: url,
+          username: username,
+          password: password
+        };
+      }
+
+      let response = await httpGitRequest('/git/clone', 'POST', obj);
       if (response.status !== 200) {
         const data = await response.json();
         throw new ServerConnection.ResponseError(response, data.message);

--- a/src/git.ts
+++ b/src/git.ts
@@ -156,31 +156,36 @@ export interface IGitPushPullResult {
 }
 
 /**
+ * Structure for the auth request.
+ */
+export interface authObject {
+  username?: string;
+  password?: string;
+}
+
+/**
  * Structure for the request to the Git Clone API.
  */
 export interface cloneObject {
   current_path: string,
-  clone_url: string,
-  username?: string;
-  password?: string;
+  clone_url: string;
+  auth?: authObject;
 }
 
 /**
  * Structure for the request to the Git Push API.
  */
 export interface pushObject {
-  current_path: string,
-  username?: string;
-  password?: string;
+  current_path: string;
+  auth?: authObject;
 }
 
 /**
  * Structure for the request to the Git Pull API.
  */
 export interface pullObject {
-  current_path: string,
-  username?: string;
-  password?: string;
+  current_path: string;
+  auth?: authObject;
 }
 
 /**
@@ -198,18 +203,17 @@ export class Git {
   constructor() {}
 
   /** Make request for the Git Pull API. */
-  async pull(path: string, username: string = '', password: string= ''): Promise<IGitPushPullResult> {
+  async pull(path: string, auth: authObject = undefined): Promise<IGitPushPullResult> {
     try {
-      if (username == '' && password == '') {
+      if (auth) {
         var obj: pullObject = { 
-          current_path: path, 
+          current_path: path,
+          auth: auth
         };
       }
       else {
         var obj: pullObject = {
-          current_path: path,
-          username: username,
-          password: password
+          current_path: path
         };
       }
 
@@ -225,18 +229,17 @@ export class Git {
   }
 
   /** Make request for the Git Push API. */
-  async push(path: string, username: string = '', password: string= ''): Promise<IGitPushPullResult> {
+  async push(path: string, auth: authObject = undefined): Promise<IGitPushPullResult> {
     try {
-      if (username == '' && password == '') {
+      if (auth) {
         var obj: pushObject = { 
-          current_path: path, 
+          current_path: path,
+          auth: auth
         };
       }
       else {
         var obj: pushObject = {
-          current_path: path,
-          username: username,
-          password: password
+          current_path: path
         };
       }
       let response = await httpGitRequest('/git/push', 'POST', obj);
@@ -252,20 +255,19 @@ export class Git {
   }
 
   /** Make request for the Git Clone API. */
-  async clone(path: string, url: string, username: string = '', password: string= ''): Promise<GitCloneResult> {
+  async clone(path: string, url: string, auth: authObject = undefined): Promise<GitCloneResult> {
     try {
-      if (username == '' && password == '') {
+      if (auth) {
         var obj: cloneObject = { 
-          current_path: path, 
-          clone_url: url
+          current_path: path,
+          clone_url: url,
+          auth: auth
         };
       }
       else {
         var obj: cloneObject = {
           current_path: path,
-          clone_url: url,
-          username: username,
-          password: password
+          clone_url: url
         };
       }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -140,6 +140,14 @@ export interface GitCloneResult {
 }
 
 /**
+ * Structure for the result of the Git Commit API.
+ */
+export interface GitCommitResult {
+  code: number;
+  message?: string;
+}
+
+/**
  * Structure for the result of the Git Push & Pull API.
  */
 export interface IGitPushPullResult {
@@ -380,18 +388,36 @@ export class Git {
     }
   }
   /** Make request to commit all staged files in repository 'path' */
-  async commit(message: string, path: string): Promise<Response> {
+  async commit(message: string, path: string, authorName: string = '', authorEmail: string= ''): Promise<GitCommitResult> {
     try {
-      let response = await httpGitRequest('/git/commit', 'POST', {
-        commit_msg: message,
-        top_repo_path: path
-      });
+      interface commitObject {
+        commit_msg: string;
+        top_repo_path: string;
+        author_name?: string;
+        author_email?: string;
+      }
+
+      if (authorName == '' && authorEmail == '') {
+        var obj: commitObject = { 
+          commit_msg: message, 
+          top_repo_path: path
+        };
+      }
+      else {
+        var obj: commitObject = {
+          commit_msg: message,
+          top_repo_path: path,
+          author_name: authorName,
+          author_email: authorEmail
+        };
+      }
+      let response = await httpGitRequest('/git/commit', 'POST', obj);
       if (response.status !== 200) {
         return response.json().then((data: any) => {
           throw new ServerConnection.ResponseError(response, data.message);
         });
       }
-      return response;
+      return response.json();
     } catch (err) {
       throw ServerConnection.NetworkError;
     }

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -15,7 +15,7 @@ import {
     style
 } from 'typestyle';
 
-import {Git} from './git';
+import {Git, authObject} from './git';
 
 import {GitCredentialsForm} from './components/CredentialsBox'
 
@@ -108,9 +108,13 @@ export class GitClone extends Widget {
                         if (result.button.label == 'OK') {
                             //user accepted attempt to login
                             //now, we can try cloning again
-                            let auth = JSON.parse(decodeURIComponent(result.value));
+                            let auth_json = JSON.parse(decodeURIComponent(result.value));
                             //call gitApi.clone again with credentials
-                            response = await this.gitApi.clone(this.fileBrowser.model.path, cloneUrl, auth.username, auth.password);
+                            let auth: authObject = {
+                                username: auth_json.username,
+                                password: auth_json.password
+                            }
+                            response = await this.gitApi.clone(this.fileBrowser.model.path, cloneUrl, auth);
                         }
                         else {
                             //user cancelled attempt to log in

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -244,8 +244,8 @@ class GitCredentialsForm extends Widget {
         const text = document.createElement('span');
         const warning = document.createElement('div');
 
-        node.className = 'jp-CredentialsForm';
-        warning.className = 'jp-CredentialsForm-warning';
+        node.className = 'jp-RedirectForm';
+        warning.className = 'jp-RedirectForm-warning';
         text.textContent = 'Enter credentials for provided repository';
         user.placeholder = 'user';
 

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -102,12 +102,9 @@ export class GitClone extends Widget {
                         dialog.dispose();
                         
                         if (result.button.label == 'OK') {
-                            let credentials = JSON.parse(decodeURIComponent(result.value));
-                            //call makeApiCall again with credentials
-                            let idx = cloneUrl.indexOf('https://')+9;
-                            let newCloneUrl = decodeURIComponent(cloneUrl).slice(0,idx) + credentials.username + ':' + credentials.password + '@' + decodeURIComponent(cloneUrl).slice(idx);
-                            
-                            this.gitApi.clone(this.fileBrowser.model.path, newCloneUrl);
+                            let auth = JSON.parse(decodeURIComponent(result.value));
+                            //call gitApi.clone again with credentials
+                            this.gitApi.clone(this.fileBrowser.model.path, cloneUrl, auth.username, auth.password);
                         }
                         else {
                             this.showErrorDialog();

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -17,6 +17,8 @@ import {
 
 import {Git} from './git';
 
+import {GitCredentialsForm} from './components/CredentialsBox'
+
 /**
  * The widget encapsulating the Git Clone UI:
  * 1. Includes the Git Clone button in the File Browser toolbar.
@@ -86,35 +88,42 @@ export class GitClone extends Widget {
     private makeApiCall(cloneUrl: string) {
         this.gitApi.clone(this.fileBrowser.model.path, cloneUrl)
             .then(async response => {
-                if (response.code != 0) {
-                    if (response.code == 128 && response.message.indexOf('could not read Username')>=0) {
-                        //request user credentials
+                let retry = false;
+                while(response.code != 0){
+                    if (response.code == 128 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Auth or timeout error')>=0)) {
+                        //request user credentials and try to clone again
                         const dialog = new Dialog({
                             title: 'Git credentials required',
-                            body: new GitCredentialsForm(),
-                            focusNodeSelector: 'input',
+                            body: new GitCredentialsForm('Enter credentials for remote repository', retry ? 'Incorrect username or password.' : ''),
                             buttons: [
                                 Dialog.cancelButton(),
                                 Dialog.okButton({label: 'OK'})
                             ]
                         });
+                        
+
                         const result = await dialog.launch();
                         dialog.dispose();
                         
                         if (result.button.label == 'OK') {
+                            //user accepted attempt to login
+                            //now, we can try cloning again
                             let auth = JSON.parse(decodeURIComponent(result.value));
                             //call gitApi.clone again with credentials
-                            this.gitApi.clone(this.fileBrowser.model.path, cloneUrl, auth.username, auth.password);
+                            response = await this.gitApi.clone(this.fileBrowser.model.path, cloneUrl, auth.username, auth.password);
                         }
                         else {
+                            //user cancelled attempt to log in
                             this.showErrorDialog();
+                            break;
                         }
-
+                        retry = true;
+                        
                     }
                     else {
                         this.showErrorDialog(response.message);
+                        break;
                     }
-                    
                 }
             })
             .catch(() => this.showErrorDialog())
@@ -214,54 +223,4 @@ class GitCloneForm extends Widget {
     getValue(): string {
         return encodeURIComponent(this.node.querySelector('input').value);
     }
-}
-
-/**
- * The UI for the credentials form
- */
-class GitCredentialsForm extends Widget {
-    
-    /**
-     * Create a redirect form.
-     */
-    constructor() {
-        super({node: GitCredentialsForm.createFormNode()});
-    }
-
-    private static createFormNode(): HTMLElement {
-        const node = document.createElement('div');
-        const label = document.createElement('label');
-        const user = document.createElement('input');
-        const password = document.createElement('input');
-        password.type = 'password';
-        password.id = 'git_password';
-
-        const text = document.createElement('span');
-        const warning = document.createElement('div');
-
-        node.className = 'jp-RedirectForm';
-        warning.className = 'jp-RedirectForm-warning';
-        text.textContent = 'Enter credentials for provided repository';
-        user.placeholder = 'user';
-
-        label.appendChild(text);
-        label.appendChild(user);
-        label.appendChild(password);
-        node.appendChild(label);
-        node.appendChild(warning);
-        return node;
-    }
-
-    /**
-     * Returns the input value.
-     */
-    getValue(): string {
-        let lines = this.node.querySelectorAll('input');
-        let credentials = {
-            username: lines[0].value,
-            password : lines[1].value,
-        }
-        return encodeURIComponent(JSON.stringify(credentials));
-    }
-
 }

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -15,9 +15,7 @@ import {
     style
 } from 'typestyle';
 
-import {
-    Git
-} from './git';
+import {Git} from './git';
 
 /**
  * The widget encapsulating the Git Clone UI:

--- a/src/gitClone.ts
+++ b/src/gitClone.ts
@@ -90,7 +90,7 @@ export class GitClone extends Widget {
             .then(async response => {
                 let retry = false;
                 while(response.code != 0){
-                    if (response.code == 128 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Auth or timeout error')>=0)) {
+                    if (response.code == 128 && (response.message.indexOf('could not read Username')>=0 || response.message.indexOf('Invalid username or password')>=0)) {
                         //request user credentials and try to clone again
                         const dialog = new Dialog({
                             title: 'Git credentials required',

--- a/tests/unit/test_clone.py
+++ b/tests/unit/test_clone.py
@@ -96,7 +96,7 @@ def test_git_clone_with_auth_success(mock_git_auth_input_wrapper):
     assert {'code': 0} == actual_response
 
 @patch('jupyterlab_git.git.git_auth_input_wrapper')
-def test_git_clone_with_auth_failure_from_git(mock_git_auth_input_wrapper):
+def test_git_clone_with_auth_wrong_repo_url_failure_from_git(mock_git_auth_input_wrapper):
     """
     Git internally will throw an error if it is an invalid URL, or if there is a permissions issue. We want to just
     relay it back to the user.
@@ -129,3 +129,38 @@ def test_git_clone_with_auth_failure_from_git(mock_git_auth_input_wrapper):
         call().communicate()
     ])
     assert {'code': 128, 'message': "fatal: repository 'ghjkhjkl' does not exist"} == actual_response
+
+@patch('jupyterlab_git.git.git_auth_input_wrapper')
+def test_git_clone_with_auth_auth_failure_from_git(mock_git_auth_input_wrapper):
+    """
+    Git internally will throw an error if it is an invalid URL, or if there is a permissions issue. We want to just
+    relay it back to the user.
+
+    """
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'ghjkhjkl'".encode('utf-8'),
+        'returncode': 128
+    }
+    process_mock.configure_mock(**attrs)
+    mock_git_auth_input_wrapper.return_value = process_mock
+
+    # When
+    auth = {
+        'username' : 'asdf', 
+        'password' : 'qwerty'
+    }
+    actual_response = Git(root_dir='/bin').clone(current_path='test_curr_path', repo_url='ghjkhjkl', auth=auth)
+
+    # Then
+    mock_git_auth_input_wrapper.assert_has_calls([
+        call(
+            command = 'git clone ghjkhjkl -q',
+            cwd = '/bin/test_curr_path',
+            username = 'asdf',
+            password = 'qwerty'
+        ),
+        call().communicate()
+    ])
+    assert {'code': 128, 'message': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'ghjkhjkl'"} == actual_response

--- a/tests/unit/test_clone.py
+++ b/tests/unit/test_clone.py
@@ -2,7 +2,7 @@ from subprocess import PIPE
 
 from mock import patch, call, Mock
 
-from jupyterlab_git.git import Git
+from jupyterlab_git.git import Git, git_auth_input_wrapper
 
 
 @patch('subprocess.Popen')
@@ -64,3 +64,33 @@ def test_git_clone_failure_from_git(mock_subproc_popen):
         call().communicate()
     ])
     assert {'code': 128, 'message': 'fatal: Not a git repository'} == actual_response
+
+@patch('jupyterlab_git.git.git_auth_input_wrapper')
+def test_git_clone_with_auth_success(mock_git_auth_input_wrapper):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': ('output', 'error'.encode('utf-8')),
+        'returncode': 0
+    }
+    process_mock.configure_mock(**attrs)
+    mock_git_auth_input_wrapper.return_value = process_mock
+
+    # When
+    auth = {
+        'username' : 'asdf', 
+        'password' : 'qwerty'
+    }
+    actual_response = Git(root_dir='/bin').clone(current_path='test_curr_path', repo_url='ghjkhjkl', auth=auth)
+
+    # Then
+    mock_git_auth_input_wrapper.assert_has_calls([
+        call(
+            command = 'git clone ghjkhjkl -q',
+            cwd = '/bin/test_curr_path',
+            username = 'asdf',
+            password = 'qwerty'
+        ),
+        call().communicate()
+    ])
+    assert {'code': 0} == actual_response

--- a/tests/unit/test_pushpull.py
+++ b/tests/unit/test_pushpull.py
@@ -2,7 +2,7 @@ from subprocess import PIPE
 
 from mock import patch, call, Mock
 
-from jupyterlab_git.git import Git
+from jupyterlab_git.git import Git, git_auth_input_wrapper
 
 
 @patch('subprocess.Popen')
@@ -32,6 +32,36 @@ def test_git_pull_fail(mock_subproc_popen):
     ])
     assert {'code': 1, 'message': 'Authentication failed'} == actual_response
 
+@patch('jupyterlab_git.git.git_auth_input_wrapper')
+def test_git_pull_with_auth_fail(mock_git_auth_input_wrapper):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'".encode('utf-8'),
+        'returncode': 1
+    }
+    process_mock.configure_mock(**attrs)
+    mock_git_auth_input_wrapper.return_value = process_mock
+
+    # When
+    auth = {
+        'username' : 'asdf', 
+        'password' : 'qwerty'
+    }
+    actual_response = Git(root_dir='/bin').pull('test_curr_path', auth)
+
+
+    # Then
+    mock_git_auth_input_wrapper.assert_has_calls([
+        call(
+            command = 'git pull --no-commit',
+            cwd='/bin/test_curr_path',
+            username = 'asdf',
+            password = 'qwerty'
+        ),
+        call().communicate()
+    ])
+    assert {'code': 1, 'message': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'"} == actual_response
 
 @patch('subprocess.Popen')
 def test_git_pull_success(mock_subproc_popen):
@@ -60,6 +90,35 @@ def test_git_pull_success(mock_subproc_popen):
     ])
     assert {'code': 0} == actual_response
 
+@patch('jupyterlab_git.git.git_auth_input_wrapper')
+def test_git_pull_with_auth_success(mock_git_auth_input_wrapper):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': ('output', ''.encode('utf-8')),
+        'returncode': 0
+    }
+    process_mock.configure_mock(**attrs)
+    mock_git_auth_input_wrapper.return_value = process_mock
+
+    # When
+    auth = {
+        'username' : 'asdf', 
+        'password' : 'qwerty'
+    }
+    actual_response = Git(root_dir='/bin').pull('test_curr_path', auth)
+
+    # Then
+    mock_git_auth_input_wrapper.assert_has_calls([
+        call(
+            command = 'git pull --no-commit',
+            cwd='/bin/test_curr_path',
+            username = 'asdf',
+            password = 'qwerty'
+        ),
+        call().communicate()
+    ])
+    assert {'code': 0} == actual_response
 
 @patch('subprocess.Popen')
 def test_git_push_fail(mock_subproc_popen):
@@ -88,6 +147,35 @@ def test_git_push_fail(mock_subproc_popen):
     ])
     assert {'code': 1, 'message': 'Authentication failed'} == actual_response
 
+@patch('jupyterlab_git.git.git_auth_input_wrapper')
+def test_git_push_with_auth_fail(mock_git_auth_input_wrapper):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'".encode('utf-8'),
+        'returncode': 1
+    }
+    process_mock.configure_mock(**attrs)
+    mock_git_auth_input_wrapper.return_value = process_mock
+
+    # When
+    auth = {
+        'username' : 'asdf', 
+        'password' : 'qwerty'
+    }
+    actual_response = Git(root_dir='/bin').push('test_origin', 'HEAD:test_master', 'test_curr_path', auth)
+
+    # Then
+    mock_git_auth_input_wrapper.assert_has_calls([
+        call(
+            command = 'git push test_origin HEAD:test_master',
+            cwd='/bin/test_curr_path',
+            username = 'asdf',
+            password = 'qwerty'
+        ),
+        call().communicate()
+    ])
+    assert {'code': 1, 'message': "remote: Invalid username or password.\r\nfatal: Authentication failed for 'repo_url'"} == actual_response
 
 @patch('subprocess.Popen')
 def test_git_push_success(mock_subproc_popen):
@@ -111,6 +199,36 @@ def test_git_push_success(mock_subproc_popen):
             stderr=PIPE,
             cwd='/bin/test_curr_path',
             shell=True
+        ),
+        call().communicate()
+    ])
+    assert {'code': 0} == actual_response
+
+@patch('jupyterlab_git.git.git_auth_input_wrapper')
+def test_git_push_with_auth_success(mock_git_auth_input_wrapper):
+    # Given
+    process_mock = Mock()
+    attrs = {
+        'communicate.return_value': 'does not matter'.encode('utf-8'),
+        'returncode': 0
+    }
+    process_mock.configure_mock(**attrs)
+    mock_git_auth_input_wrapper.return_value = process_mock
+
+    # When
+    auth = {
+        'username' : 'asdf', 
+        'password' : 'qwerty'
+    }
+    actual_response = Git(root_dir='/bin').push('.', 'HEAD:test_master', 'test_curr_path', auth)
+
+    # Then
+    mock_git_auth_input_wrapper.assert_has_calls([
+        call(
+            command = 'git push . HEAD:test_master',
+            cwd='/bin/test_curr_path',
+            username = 'asdf',
+            password = 'qwerty'
         ),
         call().communicate()
     ])


### PR DESCRIPTION
Added simple credentials support mirroring git CLI UX as requested in https://github.com/jupyterlab/jupyterlab-git/issues/299. User credentials are collected using a form and sent to backend. On the backend, API handler is overloaded to expect auth information and `Git` class methods `clone`, `push`, `pull` are updated to allow piping of username/password to CLI using [`pexpect`](https://github.com/pexpect/pexpect).